### PR TITLE
adjust enum prefix replacement logic

### DIFF
--- a/generate-icon-cases.php
+++ b/generate-icon-cases.php
@@ -12,6 +12,7 @@ $config = [
     'vendor_package' => 'afatmustafa/blade-hugeicons', // Change this to your actual package
     'icon_set_name' => 'Hugeicons', // Change this to your icon set name
     'enum_file' => 'src/Enums/Hugeicons.php', // Change this to your enum file path
+    'icon_prefix' => 'hugeicons', //change this to your icon set name
 ];
 
 echo "🔍 Icon Updater Script\n";
@@ -59,15 +60,41 @@ foreach ($svgFiles as $filename) {
 }
 
 // Create enum content
-$enumContent = "<?php
+
+$cases = implode("\n", $enumCases);
+
+$enumContent = <<<PHP
+<?php
 
 namespace Vendor\\Icons\\{$config['icon_set_name']}\\Enums;
 
-enum {$config['icon_set_name']}: string
+use Filament\\Support\\Contracts\\ScalableIcon;
+use Filament\\Support\\Enums\\IconSize;
+
+enum {$config['icon_set_name']}: string implements ScalableIcon
 {
-".implode("\n", $enumCases).'
+{$cases}
+
+    public function getIconForSize(IconSize \$size): string
+    {
+        return match (\$size) {
+            default => '{$config['icon_prefix']}-' . \$this->value,
+        };
+    }
 }
-';
+PHP;
+//$enumContent = "<?php
+//
+//namespace Vendor\\Icons\\{$config['icon_set_name']}\\Enums;
+//
+//use Filament\Support\Contracts\ScalableIcon;
+//use Filament\Support\Enums\IconSize;
+//
+//enum {$config['icon_set_name']}: string implements ScalableIcon
+//{
+//".implode("\n", $enumCases).'
+//}
+//';
 
 // Ensure the directory exists
 $enumDir = dirname($config['enum_file']);
@@ -75,6 +102,7 @@ if (! is_dir($enumDir)) {
     mkdir($enumDir, 0755, true);
     echo "📁 Created directory: {$enumDir}\n";
 }
+
 
 // Write the enum file
 file_put_contents($config['enum_file'], $enumContent);

--- a/setup.php
+++ b/setup.php
@@ -135,7 +135,6 @@ if (file_exists($enumPath)) {
     $enum = str_replace('{Vendor}\\Icons\\{IconSet}', $config['vendor_namespace'].'\\Icons\\'.$config['iconset_pascal'], $enum);
     $enum = str_replace('{Vendor}', $config['vendor_namespace'], $enum);
     $enum = str_replace('{IconSet}', $config['iconset_pascal'], $enum);
-    $enum = str_replace('{iconset}', $config['icon_prefix'], $enum);
 
     if (! $hasStyles) {
         // Remove style-related enum cases
@@ -308,6 +307,12 @@ if (file_exists($generateIconCasesPath)) {
     $generateIconCasesContent = str_replace(
         "'src/Enums/Hugeicons.php'",
         "'src/Enums/{$config['iconset_pascal']}.php'",
+        $generateIconCasesContent
+    );
+
+    $generateIconCasesContent = str_replace(
+            "'hugeicons'",
+        "'{$config['icon_prefix']}'",
         $generateIconCasesContent
     );
 

--- a/setup.php
+++ b/setup.php
@@ -135,6 +135,7 @@ if (file_exists($enumPath)) {
     $enum = str_replace('{Vendor}\\Icons\\{IconSet}', $config['vendor_namespace'].'\\Icons\\'.$config['iconset_pascal'], $enum);
     $enum = str_replace('{Vendor}', $config['vendor_namespace'], $enum);
     $enum = str_replace('{IconSet}', $config['iconset_pascal'], $enum);
+    $enum = str_replace('{iconset}', $config['icon_prefix'], $enum);
 
     if (! $hasStyles) {
         // Remove style-related enum cases

--- a/src/Enums/{IconSet}.php
+++ b/src/Enums/{IconSet}.php
@@ -2,10 +2,8 @@
 
 namespace {Vendor}\Icons\{IconSet}Enums;
 
-use Filament\Support\Contracts\ScalableIcon;
-use Filament\Support\Enums\IconSize;
 
-enum {IconSet}: string implements ScalableIcon
+enum {IconSet}: string
 {
     // Icons with consistent naming pattern
     case Search = 'search';
@@ -13,11 +11,4 @@ enum {IconSet}: string implements ScalableIcon
     case Home = 'home';
     case Filter = 'filter';
     // ... all available icons
-
-    public function getIconForSize(IconSize $size): string
-    {
-        return match ($size) {
-            default => '{iconset}-'.$this->value,
-        };
-    }
 }

--- a/src/Enums/{IconSet}.php
+++ b/src/Enums/{IconSet}.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace {Vendor}\Icons\{IconSet}\Enums;
+namespace {Vendor}\Icons\{IconSet}Enums;
 
-enum {IconSet}: string
+use Filament\Support\Contracts\ScalableIcon;
+use Filament\Support\Enums\IconSize;
+
+enum {IconSet}: string implements ScalableIcon
 {
     // Icons with consistent naming pattern
     case Search = 'search';
@@ -10,4 +13,11 @@ enum {IconSet}: string
     case Home = 'home';
     case Filter = 'filter';
     // ... all available icons
+
+    public function getIconForSize(IconSize $size): string
+    {
+        return match ($size) {
+            default => '{iconset}-'.$this->value,
+        };
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the enum getIconForSize() method didn't correctly apply the icon set prefix (e.g., solar-).

The updated implementation ensures the prefix is properly added, preventing Filament from throwing missing icon errors like
"Svg by name 'home-2-outline' from set 'default' not found."

